### PR TITLE
Tapyrusクラスの作成とregisterTimestampメソッドの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vercel
 node_modules
+agent

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.9",
         "crypto-js": "^4.2.0",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
@@ -2959,7 +2960,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/attr-accept": {
@@ -3005,6 +3005,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -3583,7 +3594,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -3850,7 +3860,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4539,6 +4548,26 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -4559,7 +4588,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7283,7 +7311,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7293,7 +7320,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -7958,6 +7984,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.9",
     "crypto-js": "^4.2.0",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",

--- a/src/utils/Tapyrus.ts
+++ b/src/utils/Tapyrus.ts
@@ -1,0 +1,78 @@
+import axios, { AxiosRequestConfig } from "axios";
+import fs from "fs";
+import https from "https";
+
+// HTTP メソッドの型
+type HttpMethod = 'GET' | 'POST';
+
+// Axios インスタンスを作成
+const instance = axios.create({
+	baseURL: 'https://wrf5wojx.api.tapyrus.chaintope.com',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer mG553ghd3mA5x3surJHTnDcIBi0nsx7SRT4QWxST94rHhtfit0ZKYAO2QhczJC56',
+  },
+});
+
+const httpsAgent = new https.Agent({
+	cert: fs.readFileSync("/path/to/certificate.pem"), // クライアント証明書のパス
+	key: fs.readFileSync("/path/to/privatekey.pem"),   // 秘密鍵のパス
+});
+
+class Tapyrus {
+  private _method: HttpMethod;
+  private _url: string = '/api/v2/timestamps'; // デフォルト値あり
+
+  constructor(method: HttpMethod, url: string) {
+    this._method = method;
+    this._url = url;
+  }
+
+  public get method(): HttpMethod {
+    return this._method;
+  }
+
+  public get url(): string {
+    return this._url;
+  }
+
+  public set method(value: HttpMethod) {
+    this._method = value;
+  }
+
+  public set url(value: string) {
+    this._url = value;
+  }
+
+	// Timestamp登録用関数
+  public async registerTimestamp(fileContent: string, filePrefix: string): Promise<string>{
+		// リクエストボディ
+    const body = {
+      content: fileContent,
+      digest: "none",
+      prefix: filePrefix,
+      type: "simple",
+    };
+
+    // Axios リクエスト設定
+    const config: AxiosRequestConfig = {
+      method: this._method,
+      url: this._url,
+      data: body,
+      httpsAgent: httpsAgent,
+    };
+
+    try {
+      const response = await instance(config);
+      return response.data; // サーバーからのレスポンスを返す
+    } catch (error: any) {
+      console.error("Error occurred while registering timestamp:", error);
+      if (error.response) {
+        console.error("Response data:", error.response.data);
+      }
+      throw error; // エラーハンドリングを呼び出し側に委ねる
+    }
+  }
+}
+
+export default Tapyrus;

--- a/src/utils/Tapyrus.ts
+++ b/src/utils/Tapyrus.ts
@@ -1,25 +1,45 @@
-import axios, { AxiosRequestConfig } from "axios";
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosError } from "axios";
 import fs from "fs";
 import https from "https";
 
 // HTTP メソッドの型
 type HttpMethod = 'GET' | 'POST';
 
-// Axios インスタンスを作成
-const instance = axios.create({
-	baseURL: 'https://wrf5wojx.api.tapyrus.chaintope.com',
-  headers: {
-    'Content-Type': 'application/json',
-    'Authorization': 'Bearer mG553ghd3mA5x3surJHTnDcIBi0nsx7SRT4QWxST94rHhtfit0ZKYAO2QhczJC56',
-  },
-});
+interface TapyrusResponse {
+	id: number;
+	version: string; 
+	txid: string | null;
+	status: string;
+	content_hash: string;	
+	prefix: string;
+	wallet_id: string;
+	timestamp_type: string;
+	block_height: number | null;
+	block_time: number | null;
+};
 
 const httpsAgent = new https.Agent({
-	cert: fs.readFileSync("/path/to/certificate.pem"), // クライアント証明書のパス
-	key: fs.readFileSync("/path/to/privatekey.pem"),   // 秘密鍵のパス
+	cert: fs.readFileSync("/home/File-Timestamp-App/agent/cert.pem"), // クライアント証明書のパス
+	rejectUnauthorized: true,
 });
 
-class Tapyrus {
+// Axios インスタンスを作成
+let instance: AxiosInstance | null = null;
+
+function getAxiosInstance(): AxiosInstance{
+	if(!instance){
+		instance = axios.create({
+			baseURL: 'https://wrf5wojx.api.tapyrus.chaintope.com',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': 'Bearer mG553ghd3mA5x3surJHTnDcIBi0nsx7SRT4QWxST94rHhtfit0ZKYAO2QhczJC56',
+			},
+			httpsAgent,
+		});
+	}
+	return instance;
+}
+export class Tapyrus {
   private _method: HttpMethod;
   private _url: string = '/api/v2/timestamps'; // デフォルト値あり
 
@@ -45,7 +65,7 @@ class Tapyrus {
   }
 
 	// Timestamp登録用関数
-  public async registerTimestamp(fileContent: string, filePrefix: string): Promise<string>{
+  public async registerTimestamp(fileContent: string, filePrefix: string): Promise<TapyrusResponse>{
 		// リクエストボディ
     const body = {
       content: fileContent,
@@ -59,20 +79,23 @@ class Tapyrus {
       method: this._method,
       url: this._url,
       data: body,
-      httpsAgent: httpsAgent,
     };
+		console.log(instance);
 
     try {
-      const response = await instance(config);
+      const response = await getAxiosInstance().request(config);
       return response.data; // サーバーからのレスポンスを返す
-    } catch (error: any) {
-      console.error("Error occurred while registering timestamp:", error);
-      if (error.response) {
-        console.error("Response data:", error.response.data);
-      }
-      throw error; // エラーハンドリングを呼び出し側に委ねる
+    } catch (error: unknown) {
+			if (axios.isAxiosError(error)) {
+				const axiosError = error as AxiosError;
+	      console.error("Axios error while registering timestamp:", AxiosError);
+				if (axiosError.response) {
+					console.error("Response data:", axiosError.response.data)
+				}
+			} else {
+					console.error("Unexpected error:", error);
+     	 		throw error; // エラーハンドリングを呼び出し側に委ねる
+			}
     }
   }
 }
-
-export default Tapyrus;

--- a/src/utils/Tapyrus_mocked.test.ts
+++ b/src/utils/Tapyrus_mocked.test.ts
@@ -1,0 +1,83 @@
+import {Tapyrus} from "./Tapyrus";
+import axios, {AxiosInstance} from 'axios';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+
+describe('Tapyrus', () => {
+  let tapyrus: Tapyrus;
+	
+  beforeEach(() => {
+		mockedAxios.create.mockReturnValue(mockedAxios as unknown as AxiosInstance);
+		mockedAxios.request = jest.fn();
+    tapyrus = new Tapyrus('POST', '/api/v2/timestamps');
+		jest.clearAllMocks();
+  });
+
+  it('should set and get method correctly', () => {
+    expect(tapyrus.method).toBe('POST');
+  });
+
+  it('should set and get url correctly', () => {
+    expect(tapyrus.url).toBe('/api/v2/timestamps');
+  });
+
+  it('should register timestamp successfully', async () => {
+		const mockResponse = {
+			data: {
+				"id": 1,
+				"version": "2",
+				"txid": "6fce02d39279f6d645ecc710ebcf1dbb7b8104106553d8da13f5db79c5a628fc",
+				"status": "confirmed",
+				"content_hash": "7b226669656c6431223a202276616c756531227d",
+				"prefix": "74657374617070",
+				"wallet_id": "b831e51927edc7b3a21869909d526e51",
+				"timestamp_type": "simple",
+				"block_height": 101,
+				"block_time": 1626169080
+			},
+		};
+		
+		(mockedAxios.request as jest.Mock).mockResolvedValueOnce( mockResponse );
+
+    const fileContent = '7b226669656c6431223a202276616c756531227d';
+    const filePrefix = '74657374617070';
+
+    const result = await tapyrus.registerTimestamp(fileContent, filePrefix);
+
+    expect(result).toEqual(mockResponse.data);
+		expect(mockedAxios.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				baseURL: 'https://wrf5wojx.api.tapyrus.chaintope.com',
+				headers: {
+					'Content-Type': 'application/json',
+					'Authorization': 'Bearer mG553ghd3mA5x3surJHTnDcIBi0nsx7SRT4QWxST94rHhtfit0ZKYAO2QhczJC56',
+				},
+			})
+		);
+    expect(mockedAxios.request).toHaveBeenCalledWith(
+			expect.objectContaining({
+        method: 'POST',
+        url: '/api/v2/timestamps',
+        data: {
+          content: '7b226669656c6431223a202276616c756531227d',
+          digest: 'none',
+          prefix: '74657374617070',
+          type: 'simple',
+        },
+      })
+		);
+
+  });
+
+  it('should handle error during timestamp registration', async () => {
+    const errorMessage = "Test error"; 
+		(mockedAxios.request as jest.Mock).mockRejectedValueOnce(new Error(errorMessage));
+		const fileContent = 'file content';
+    const filePrefix = 'prefix';
+
+		await expect(tapyrus.registerTimestamp(fileContent, filePrefix)).rejects.toThrow(errorMessage);
+  });
+});
+

--- a/src/utils/Tapyrus_real.test.ts
+++ b/src/utils/Tapyrus_real.test.ts
@@ -1,0 +1,34 @@
+import { Tapyrus } from "./Tapyrus";
+
+describe("Tapyrus API Integration Test", () => {
+  let tapyrus: Tapyrus;
+
+  beforeEach(() => {
+    tapyrus = new Tapyrus("POST", "/api/v2/timestamps");
+  });
+
+  it("should successfully register a timestamp with the real API", async () => {
+    // 実際にAPIへ送信するデータ
+    const fileContent = "7b226669656c6431223a202276616c756531227d";
+    const filePrefix = "74657374617070";
+
+    // API を実際に叩く
+    const result = await tapyrus.registerTimestamp(fileContent, filePrefix);
+
+    // レスポンスの検証
+    console.log("API Response:", result);
+    expect(result).toHaveProperty("id");
+    expect(result).toHaveProperty("txid");
+    expect(result).toHaveProperty("status");
+    expect(result.status).toBe("unconfirmed");
+  }, 30000); // タイムアウトを 30 秒に延長
+
+	it("should handle API error correctly", async () => {
+		const fileContent = "fileContent"; // 無効なデータ
+		const filePrefix = "filePrefix";
+		jest.spyOn(console, "error").mockImplementation(() => {}); // エラー出力を監視
+		await tapyrus.registerTimestamp(fileContent, filePrefix);
+
+		expect(console.error).toHaveBeenCalled(); // エラーがログに記録されたか
+	});
+});


### PR DESCRIPTION
 ### 変更点

- Tapyrusクラスの作成(Tapyrus.ts)
- registerTimestampメソッドの作成(Tapyrus.ts)
- Mockでのテスト作成(Tapyrus_mocked.test.ts)
- 実際のAPIの通信テスト作成(Tapyrus_real.test.ts)

### 実装の詳細

- インターフェイスとしてTapyrusResponse追加
- Tapyrusクラス内に_method, _urlプロパティとそれぞれのgetter,setter実装
- Tapyrusクラス内にregisterTimestamp(fileprefix: string, filecontent: string):<promise>TapyrusResponse実装
- それぞれのテスト作成

### テスト

- [x] getter,setterが作動すること
- [x] registerTimestampメソッドが引数を受け取り、TapyrusResponse型インターフェイスで返すこと
- [x] registerTimestampメソッドが実際にAPIと通信できること
- [x] エラーレスポンスを受け取れること